### PR TITLE
Add Playwright-powered console extractor for Google Maps lists

### DIFF
--- a/Console.TripperistaListExtractor.Tests/Console.TripperistaListExtractor.Tests.csproj
+++ b/Console.TripperistaListExtractor.Tests/Console.TripperistaListExtractor.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.4.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.4.3" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Core.TripperistaListExtractor/Core.TripperistaListExtractor.csproj" />
+    <ProjectReference Include="../Service.TripperistaListExtractor/Service.TripperistaListExtractor.csproj" />
+  </ItemGroup>
+</Project>

--- a/Console.TripperistaListExtractor.Tests/Parsers/SavedListPayloadParserTests.cs
+++ b/Console.TripperistaListExtractor.Tests/Parsers/SavedListPayloadParserTests.cs
@@ -1,0 +1,70 @@
+namespace Console.TripperistaListExtractor.Tests.Parsers;
+
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Service.TripperistaListExtractor.Parsers;
+
+/// <summary>
+///     Provides regression coverage for the <see cref="SavedListPayloadParser"/> component.
+/// </summary>
+[TestClass]
+public sealed class SavedListPayloadParserTests
+{
+    /// <summary>
+    ///     Ensures the parser can map a simplified payload into strongly typed objects.
+    /// </summary>
+    [TestMethod]
+    public void Parse_ShouldPopulateSavedList()
+    {
+        const string json = """
+        [
+            "Sample List",
+            "A friendly description",
+            null,
+            null,
+            [
+                [
+                    null,
+                    [
+                        null,
+                        null,
+                        "123 Example Street",
+                        null,
+                        "",
+                        [null, null, 51.1234, -0.5678]
+                    ],
+                    "Example Place",
+                    "Remember to visit",
+                    null,
+                    null,
+                    null,
+                    [],
+                    [],
+                    [],
+                    [],
+                    null,
+                    ["Creator", "https://example.com/avatar.png", "id"]
+                ]
+            ]
+        ]
+        """;
+
+        using var document = JsonDocument.Parse(json);
+        var parser = new SavedListPayloadParser();
+
+        var result = parser.Parse(document.RootElement);
+
+        result.Should().NotBeNull();
+        result.Header.Name.Should().Be("Sample List");
+        result.Header.Description.Should().Be("A friendly description");
+        result.Places.Should().HaveCount(1);
+
+        var place = result.Places[0];
+        place.Name.Should().Be("Example Place");
+        place.Address.Should().Be("123 Example Street");
+        place.Note.Should().Be("Remember to visit");
+        place.Latitude.Should().BeApproximately(51.1234, 0.0001);
+        place.Longitude.Should().BeApproximately(-0.5678, 0.0001);
+    }
+}

--- a/Console.TripperistaListExtractor/Commands/ListExtractionCommandHandler.cs
+++ b/Console.TripperistaListExtractor/Commands/ListExtractionCommandHandler.cs
@@ -1,0 +1,124 @@
+namespace Console.TripperistaListExtractor.Commands;
+
+using System.IO;
+using System.Text;
+using Console.TripperistaListExtractor.Hosting;
+using Core.TripperistaListExtractor.Commands;
+using Core.TripperistaListExtractor.Models;
+using Core.TripperistaListExtractor.Options;
+using Microsoft.Extensions.Logging;
+using Service.TripperistaListExtractor.Contracts;
+
+/// <summary>
+///     Implements the concrete command used to orchestrate the end-to-end extraction workflow.
+/// </summary>
+public sealed class ListExtractionCommandHandler(
+    ResourceBundle resourceBundle,
+    ILogger<ListExtractionCommandHandler> logger,
+    IGoogleMapsListExtractorService extractorService,
+    IFileWriterFactory fileWriterFactory
+) : CommandHandler<ExtractionOptions>(resourceBundle.LogResourceManager, resourceBundle.ErrorResourceManager)
+{
+    private readonly ILogger<ListExtractionCommandHandler> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    private readonly IGoogleMapsListExtractorService _extractorService = extractorService ?? throw new ArgumentNullException(nameof(extractorService));
+    private readonly IFileWriterFactory _fileWriterFactory = fileWriterFactory ?? throw new ArgumentNullException(nameof(fileWriterFactory));
+
+    /// <inheritdoc />
+    protected override async Task<int> ExecuteInternalAsync(ExtractionOptions options, CancellationToken cancellationToken)
+    {
+        var inputUri = new Uri(options.InputSavedListUrl!, UriKind.Absolute);
+        using var scope = _logger.BeginScope("InputUrl:{InputUrl}", inputUri);
+
+        _logger.LogInformation(GetLogMessage("ExtractionStarting"), inputUri);
+
+        SavedList savedList;
+        try
+        {
+            savedList = await _extractorService.ExtractAsync(inputUri, options.Verbose, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, GetErrorMessage("ExtractionFailed"), inputUri);
+            return -1;
+        }
+
+        var baseFileName = CreateSafeFileStem(savedList.Header.Name);
+        var kmlPath = ResolveOutputPath(options.OutputKmlFile, baseFileName, ".kml");
+        var csvPath = ResolveOutputPath(options.OutputCsvFile, baseFileName, ".csv");
+
+        try
+        {
+            if (!string.IsNullOrWhiteSpace(kmlPath))
+            {
+                _logger.LogInformation(GetLogMessage("WritingKmlMessage"), kmlPath);
+                var kmlWriter = _fileWriterFactory.CreateKmlWriter();
+                await kmlWriter.WriteAsync(savedList, kmlPath!, cancellationToken).ConfigureAwait(false);
+            }
+
+            if (!string.IsNullOrWhiteSpace(csvPath))
+            {
+                _logger.LogInformation(GetLogMessage("WritingCsvMessage"), csvPath);
+                var csvWriter = _fileWriterFactory.CreateCsvWriter();
+                await csvWriter.WriteAsync(savedList, csvPath!, cancellationToken).ConfigureAwait(false);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, GetErrorMessage("FileWriteFailed"));
+            return -2;
+        }
+
+        _logger.LogInformation(GetLogMessage("ExtractionCompleted"), savedList.Places.Count);
+        return 0;
+    }
+
+    /// <summary>
+    ///     Builds a deterministic file path using the supplied file name or a safe representation of the list title.
+    /// </summary>
+    /// <param name="providedPath">The file name supplied on the command line.</param>
+    /// <param name="fallbackStem">The fallback file stem derived from the list name.</param>
+    /// <param name="extension">The expected file extension including the leading dot.</param>
+    /// <returns>The fully qualified file path.</returns>
+    private static string ResolveOutputPath(string? providedPath, string fallbackStem, string extension)
+    {
+        var candidate = providedPath;
+        if (string.IsNullOrWhiteSpace(candidate))
+        {
+            candidate = fallbackStem + extension;
+        }
+        else if (!candidate.EndsWith(extension, StringComparison.OrdinalIgnoreCase))
+        {
+            candidate = candidate + extension;
+        }
+
+        var directory = Path.GetDirectoryName(candidate);
+        if (!string.IsNullOrWhiteSpace(directory) && !Directory.Exists(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        return Path.GetFullPath(candidate!);
+    }
+
+    /// <summary>
+    ///     Sanitises the supplied stem to ensure it can be used as a file name on all platforms.
+    /// </summary>
+    /// <param name="name">The original name extracted from the saved list.</param>
+    /// <returns>A safe file stem.</returns>
+    private static string CreateSafeFileStem(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return "tripperista-list";
+        }
+
+        var invalidCharacters = Path.GetInvalidFileNameChars();
+        var builder = new StringBuilder(name.Length);
+        foreach (var ch in name)
+        {
+            builder.Append(Array.IndexOf(invalidCharacters, ch) >= 0 ? '_' : ch);
+        }
+
+        return builder.ToString().Trim();
+    }
+}

--- a/Console.TripperistaListExtractor/Console.TripperistaListExtractor.csproj
+++ b/Console.TripperistaListExtractor/Console.TripperistaListExtractor.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Core.TripperistaListExtractor/Core.TripperistaListExtractor.csproj" />
+    <ProjectReference Include="../Service.TripperistaListExtractor/Service.TripperistaListExtractor.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Resources/LogMessages.resx" />
+    <EmbeddedResource Include="Resources/ErrorMessages.resx" />
+  </ItemGroup>
+</Project>

--- a/Console.TripperistaListExtractor/Hosting/ResourceBundle.cs
+++ b/Console.TripperistaListExtractor/Hosting/ResourceBundle.cs
@@ -1,0 +1,30 @@
+namespace Console.TripperistaListExtractor.Hosting;
+
+using System.Resources;
+
+/// <summary>
+///     Encapsulates the resource managers required for localised log and error messages.
+/// </summary>
+public sealed class ResourceBundle
+{
+    /// <summary>
+    ///     Initialises a new instance of the <see cref="ResourceBundle"/> class.
+    /// </summary>
+    /// <param name="logResourceManager">The resource manager responsible for log messages.</param>
+    /// <param name="errorResourceManager">The resource manager responsible for error messages.</param>
+    public ResourceBundle(ResourceManager logResourceManager, ResourceManager errorResourceManager)
+    {
+        LogResourceManager = logResourceManager ?? throw new ArgumentNullException(nameof(logResourceManager));
+        ErrorResourceManager = errorResourceManager ?? throw new ArgumentNullException(nameof(errorResourceManager));
+    }
+
+    /// <summary>
+    ///     Gets the resource manager that resolves log messages.
+    /// </summary>
+    public ResourceManager LogResourceManager { get; }
+
+    /// <summary>
+    ///     Gets the resource manager that resolves error messages.
+    /// </summary>
+    public ResourceManager ErrorResourceManager { get; }
+}

--- a/Console.TripperistaListExtractor/Program.cs
+++ b/Console.TripperistaListExtractor/Program.cs
@@ -1,0 +1,71 @@
+using System.Resources;
+using Console.TripperistaListExtractor.Commands;
+using Console.TripperistaListExtractor.Hosting;
+using Core.TripperistaListExtractor.Configuration;
+using Core.TripperistaListExtractor.Options;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Service.TripperistaListExtractor.Contracts;
+using Service.TripperistaListExtractor.Implementations;
+using Service.TripperistaListExtractor.Parsers;
+using Service.TripperistaListExtractor.Writers;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.Configuration.AddJsonFile("appsettings.json", optional: true, reloadOnChange: false);
+builder.Configuration.AddEnvironmentVariables();
+builder.Configuration.AddCommandLine(args);
+
+builder.Services.AddLogging(logging =>
+{
+    logging.ClearProviders();
+    logging.AddConsole();
+    logging.SetMinimumLevel(LogLevel.Information);
+});
+
+builder.Services
+    .AddOptions<ExtractionOptions>()
+    .Bind(builder.Configuration)
+    .ValidateDataAnnotations();
+
+builder.Services.Configure<GoogleApiSettings>(builder.Configuration.GetSection("GooglePlaces"));
+
+builder.Services.AddSingleton(new ResourceBundle(
+    new ResourceManager("Console.TripperistaListExtractor.Resources.LogMessages", typeof(Program).Assembly),
+    new ResourceManager("Console.TripperistaListExtractor.Resources.ErrorMessages", typeof(Program).Assembly)));
+
+builder.Services.AddSingleton<ISavedListPayloadParser, SavedListPayloadParser>();
+builder.Services.AddSingleton<IGoogleMapsListExtractorService, GoogleMapsListExtractorService>();
+builder.Services.AddTransient<ICsvFileWriter, CsvFileWriter>();
+builder.Services.AddTransient<IKmlFileWriter, KmlFileWriter>();
+builder.Services.AddSingleton<IFileWriterFactory, FileWriterFactory>();
+builder.Services.AddSingleton<ListExtractionCommandHandler>();
+
+using var host = builder.Build();
+var options = host.Services.GetRequiredService<IOptions<ExtractionOptions>>().Value;
+var handler = host.Services.GetRequiredService<ListExtractionCommandHandler>();
+
+using var cancellationSource = new CancellationTokenSource();
+Console.CancelKeyPress += (_, eventArgs) =>
+{
+    eventArgs.Cancel = true;
+    cancellationSource.Cancel();
+};
+
+try
+{
+    await host.StartAsync(cancellationSource.Token).ConfigureAwait(false);
+    var exitCode = await handler.ExecuteAsync(options, cancellationSource.Token).ConfigureAwait(false);
+    Environment.ExitCode = exitCode;
+}
+catch (OperationCanceledException)
+{
+    Environment.ExitCode = -3;
+}
+finally
+{
+    await host.StopAsync().ConfigureAwait(false);
+}

--- a/Console.TripperistaListExtractor/Resources/ErrorMessages.resx
+++ b/Console.TripperistaListExtractor/Resources/ErrorMessages.resx
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ExtractionFailed" xml:space="preserve">
+    <value>Failed to extract saved list data from {0}.</value>
+  </data>
+  <data name="FileWriteFailed" xml:space="preserve">
+    <value>Unable to persist the requested output files.</value>
+  </data>
+</root>

--- a/Console.TripperistaListExtractor/Resources/LogMessages.resx
+++ b/Console.TripperistaListExtractor/Resources/LogMessages.resx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ExtractionStarting" xml:space="preserve">
+    <value>Starting extraction for {0}.</value>
+  </data>
+  <data name="WritingKmlMessage" xml:space="preserve">
+    <value>Writing KML output to {0}.</value>
+  </data>
+  <data name="WritingCsvMessage" xml:space="preserve">
+    <value>Writing CSV output to {0}.</value>
+  </data>
+  <data name="ExtractionCompleted" xml:space="preserve">
+    <value>Extraction completed successfully with {0} places discovered.</value>
+  </data>
+</root>

--- a/Console.TripperistaListExtractor/appsettings.json
+++ b/Console.TripperistaListExtractor/appsettings.json
@@ -1,0 +1,10 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information"
+    }
+  },
+  "GooglePlaces": {
+    "ApiKey": ""
+  }
+}

--- a/Core.TripperistaListExtractor/Commands/CommandHandler.cs
+++ b/Core.TripperistaListExtractor/Commands/CommandHandler.cs
@@ -1,0 +1,87 @@
+namespace Core.TripperistaListExtractor.Commands;
+
+using System.ComponentModel.DataAnnotations;
+using System.Globalization;
+using System.Resources;
+
+/// <summary>
+///     Provides a reusable template for executing console commands using strongly-typed option payloads.
+/// </summary>
+/// <typeparam name="TOptions">The option type that is validated and consumed by the command.</typeparam>
+public abstract class CommandHandler<TOptions>
+    where TOptions : class, new()
+{
+    /// <summary>
+    ///     Initialises a new instance of the <see cref="CommandHandler{TOptions}"/> class.
+    /// </summary>
+    /// <param name="logResourceManager">The resource manager that provides localised log messages.</param>
+    /// <param name="errorResourceManager">The resource manager that provides localised error messages.</param>
+    protected CommandHandler(ResourceManager logResourceManager, ResourceManager errorResourceManager)
+    {
+        LogResourceManager = logResourceManager ?? throw new ArgumentNullException(nameof(logResourceManager));
+        ErrorResourceManager = errorResourceManager ?? throw new ArgumentNullException(nameof(errorResourceManager));
+    }
+
+    /// <summary>
+    ///     Gets the resource manager that resolves log messages for derived handlers.
+    /// </summary>
+    protected ResourceManager LogResourceManager { get; }
+
+    /// <summary>
+    ///     Gets the resource manager that resolves error messages for derived handlers.
+    /// </summary>
+    protected ResourceManager ErrorResourceManager { get; }
+
+    /// <summary>
+    ///     Executes the command using the provided option payload and cancellation token.
+    /// </summary>
+    /// <param name="options">The bound option set supplied by the command line.</param>
+    /// <param name="cancellationToken">The cancellation token associated with the hosting infrastructure.</param>
+    /// <returns>A task that resolves to the process exit code.</returns>
+    public async Task<int> ExecuteAsync(TOptions options, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ValidateOptions(options);
+        return await ExecuteInternalAsync(options, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    ///     Performs the option-specific validation using <see cref="Validator"/> and the <see cref="ValidationContext"/>.
+    /// </summary>
+    /// <param name="options">The option payload to validate.</param>
+    protected virtual void ValidateOptions(TOptions options)
+    {
+        var validationContext = new ValidationContext(options, serviceProvider: null, items: null);
+        Validator.ValidateObject(options, validationContext, validateAllProperties: true);
+    }
+
+    /// <summary>
+    ///     Deriving classes must implement the command logic that returns an exit code.
+    /// </summary>
+    /// <param name="options">The validated option payload.</param>
+    /// <param name="cancellationToken">The cancellation token that propagates shutdown requests.</param>
+    /// <returns>A task representing the asynchronous execution result.</returns>
+    protected abstract Task<int> ExecuteInternalAsync(TOptions options, CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Retrieves a localised log message for the supplied key.
+    /// </summary>
+    /// <param name="resourceKey">The resource key to resolve.</param>
+    /// <returns>The formatted localised message.</returns>
+    protected string GetLogMessage(string resourceKey)
+    {
+        var message = LogResourceManager.GetString(resourceKey, CultureInfo.CurrentCulture);
+        return message ?? string.Empty;
+    }
+
+    /// <summary>
+    ///     Retrieves a localised error message for the supplied key.
+    /// </summary>
+    /// <param name="resourceKey">The resource key to resolve.</param>
+    /// <returns>The formatted localised message.</returns>
+    protected string GetErrorMessage(string resourceKey)
+    {
+        var message = ErrorResourceManager.GetString(resourceKey, CultureInfo.CurrentCulture);
+        return message ?? string.Empty;
+    }
+}

--- a/Core.TripperistaListExtractor/Configuration/GoogleApiSettings.cs
+++ b/Core.TripperistaListExtractor/Configuration/GoogleApiSettings.cs
@@ -1,0 +1,15 @@
+namespace Core.TripperistaListExtractor.Configuration;
+
+using System.ComponentModel.DataAnnotations;
+
+/// <summary>
+///     Represents the strongly-typed configuration section used to supply Google Places credentials.
+/// </summary>
+public sealed class GoogleApiSettings
+{
+    /// <summary>
+    ///     Gets or sets the API key that authorises Google Places requests.
+    /// </summary>
+    [Required(AllowEmptyStrings = false, ErrorMessage = "The Google Places API key cannot be empty.")]
+    public string? ApiKey { get; set; }
+}

--- a/Core.TripperistaListExtractor/Core.TripperistaListExtractor.csproj
+++ b/Core.TripperistaListExtractor/Core.TripperistaListExtractor.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+</Project>

--- a/Core.TripperistaListExtractor/Models/SavedList.cs
+++ b/Core.TripperistaListExtractor/Models/SavedList.cs
@@ -1,0 +1,19 @@
+namespace Core.TripperistaListExtractor.Models;
+
+using System.Collections.ObjectModel;
+
+/// <summary>
+///     Represents the aggregate root that holds the saved list header and its places.
+/// </summary>
+public sealed class SavedList
+{
+    /// <summary>
+    ///     Gets or sets the header metadata describing the list.
+    /// </summary>
+    public SavedListHeader Header { get; set; } = new();
+
+    /// <summary>
+    ///     Gets the places contained in the saved list.
+    /// </summary>
+    public Collection<SavedPlace> Places { get; } = new();
+}

--- a/Core.TripperistaListExtractor/Models/SavedListHeader.cs
+++ b/Core.TripperistaListExtractor/Models/SavedListHeader.cs
@@ -1,0 +1,27 @@
+namespace Core.TripperistaListExtractor.Models;
+
+/// <summary>
+///     Represents the metadata that accompanies a Google Maps saved list.
+/// </summary>
+public sealed class SavedListHeader
+{
+    /// <summary>
+    ///     Gets or sets the title of the Google Maps list.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    ///     Gets or sets the description authored for the list.
+    /// </summary>
+    public string? Description { get; set; }
+
+    /// <summary>
+    ///     Gets or sets the name of the list creator.
+    /// </summary>
+    public string Creator { get; set; } = string.Empty;
+
+    /// <summary>
+    ///     Gets or sets the source URL for the creator's avatar when available.
+    /// </summary>
+    public string? CreatorImageUrl { get; set; }
+}

--- a/Core.TripperistaListExtractor/Models/SavedPlace.cs
+++ b/Core.TripperistaListExtractor/Models/SavedPlace.cs
@@ -1,0 +1,37 @@
+namespace Core.TripperistaListExtractor.Models;
+
+/// <summary>
+///     Represents a single place entry within a Google Maps saved list.
+/// </summary>
+public sealed class SavedPlace
+{
+    /// <summary>
+    ///     Gets or sets the public facing place name.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    ///     Gets or sets the full address string provided by Google Maps.
+    /// </summary>
+    public string? Address { get; set; }
+
+    /// <summary>
+    ///     Gets or sets the latitude component of the place coordinates.
+    /// </summary>
+    public double? Latitude { get; set; }
+
+    /// <summary>
+    ///     Gets or sets the longitude component of the place coordinates.
+    /// </summary>
+    public double? Longitude { get; set; }
+
+    /// <summary>
+    ///     Gets or sets the optional note supplied by the list author.
+    /// </summary>
+    public string? Note { get; set; }
+
+    /// <summary>
+    ///     Gets or sets the optional image URL associated with the place entry.
+    /// </summary>
+    public string? ImageUrl { get; set; }
+}

--- a/Core.TripperistaListExtractor/Options/ExtractionOptions.cs
+++ b/Core.TripperistaListExtractor/Options/ExtractionOptions.cs
@@ -1,0 +1,38 @@
+namespace Core.TripperistaListExtractor.Options;
+
+using System.ComponentModel.DataAnnotations;
+
+/// <summary>
+///     Represents the command-line options that control the behaviour of the list extraction workflow.
+/// </summary>
+public sealed class ExtractionOptions
+{
+    /// <summary>
+    ///     Gets or sets the Google Maps saved list URL that should be scraped.
+    /// </summary>
+    [Required(AllowEmptyStrings = false, ErrorMessage = "The input saved list URL must be provided.")]
+    [Url(ErrorMessage = "The input saved list URL must be a valid absolute URI.")]
+    public string? InputSavedListUrl { get; set; }
+
+    /// <summary>
+    ///     Gets or sets the custom KML file name to generate. When omitted the list title will be used.
+    /// </summary>
+    [FileExtensions(Extensions = "kml", ErrorMessage = "The KML output must have a .kml extension.")]
+    public string? OutputKmlFile { get; set; }
+
+    /// <summary>
+    ///     Gets or sets the custom CSV file name to generate. When omitted the list title will be used.
+    /// </summary>
+    [FileExtensions(Extensions = "csv", ErrorMessage = "The CSV output must have a .csv extension.")]
+    public string? OutputCsvFile { get; set; }
+
+    /// <summary>
+    ///     Gets or sets the Google Places API key that augments the scraping results.
+    /// </summary>
+    public string? GooglePlacesApiKey { get; set; }
+
+    /// <summary>
+    ///     Gets or sets a value indicating whether verbose console logging should be enabled.
+    /// </summary>
+    public bool Verbose { get; set; }
+}

--- a/Service.TripperistaListExtractor/Contracts/ICsvFileWriter.cs
+++ b/Service.TripperistaListExtractor/Contracts/ICsvFileWriter.cs
@@ -1,0 +1,18 @@
+namespace Service.TripperistaListExtractor.Contracts;
+
+using Core.TripperistaListExtractor.Models;
+
+/// <summary>
+///     Defines a component that can persist saved list data to a CSV file.
+/// </summary>
+public interface ICsvFileWriter
+{
+    /// <summary>
+    ///     Writes the supplied saved list to a CSV document.
+    /// </summary>
+    /// <param name="list">The saved list to serialise.</param>
+    /// <param name="filePath">The destination file path.</param>
+    /// <param name="cancellationToken">The cancellation token that coordinates shutdown.</param>
+    /// <returns>A task that completes when the file has been written.</returns>
+    Task WriteAsync(SavedList list, string filePath, CancellationToken cancellationToken);
+}

--- a/Service.TripperistaListExtractor/Contracts/IFileWriterFactory.cs
+++ b/Service.TripperistaListExtractor/Contracts/IFileWriterFactory.cs
@@ -1,0 +1,19 @@
+namespace Service.TripperistaListExtractor.Contracts;
+
+/// <summary>
+///     Implements the factory pattern to build file writer services on demand.
+/// </summary>
+public interface IFileWriterFactory
+{
+    /// <summary>
+    ///     Resolves a CSV writer implementation.
+    /// </summary>
+    /// <returns>The CSV writer service.</returns>
+    ICsvFileWriter CreateCsvWriter();
+
+    /// <summary>
+    ///     Resolves a KML writer implementation.
+    /// </summary>
+    /// <returns>The KML writer service.</returns>
+    IKmlFileWriter CreateKmlWriter();
+}

--- a/Service.TripperistaListExtractor/Contracts/IGoogleMapsListExtractorService.cs
+++ b/Service.TripperistaListExtractor/Contracts/IGoogleMapsListExtractorService.cs
@@ -1,0 +1,18 @@
+namespace Service.TripperistaListExtractor.Contracts;
+
+using Core.TripperistaListExtractor.Models;
+
+/// <summary>
+///     Defines the behaviour required to extract saved list information from Google Maps.
+/// </summary>
+public interface IGoogleMapsListExtractorService
+{
+    /// <summary>
+    ///     Extracts the saved list information located at the specified URI.
+    /// </summary>
+    /// <param name="listUri">The URI of the Google Maps saved list.</param>
+    /// <param name="verbose">A value indicating whether verbose diagnostics should be emitted.</param>
+    /// <param name="cancellationToken">The cancellation token that coordinates shutdown.</param>
+    /// <returns>The fully populated saved list.</returns>
+    Task<SavedList> ExtractAsync(Uri listUri, bool verbose, CancellationToken cancellationToken);
+}

--- a/Service.TripperistaListExtractor/Contracts/IKmlFileWriter.cs
+++ b/Service.TripperistaListExtractor/Contracts/IKmlFileWriter.cs
@@ -1,0 +1,18 @@
+namespace Service.TripperistaListExtractor.Contracts;
+
+using Core.TripperistaListExtractor.Models;
+
+/// <summary>
+///     Exposes the behaviour required to persist saved list data to a KML file.
+/// </summary>
+public interface IKmlFileWriter
+{
+    /// <summary>
+    ///     Writes the supplied saved list to the specified KML file path.
+    /// </summary>
+    /// <param name="list">The saved list to serialise.</param>
+    /// <param name="filePath">The destination file path.</param>
+    /// <param name="cancellationToken">The cancellation token that coordinates shutdown.</param>
+    /// <returns>A task that completes when the file has been written.</returns>
+    Task WriteAsync(SavedList list, string filePath, CancellationToken cancellationToken);
+}

--- a/Service.TripperistaListExtractor/Contracts/ISavedListPayloadParser.cs
+++ b/Service.TripperistaListExtractor/Contracts/ISavedListPayloadParser.cs
@@ -1,0 +1,17 @@
+namespace Service.TripperistaListExtractor.Contracts;
+
+using Core.TripperistaListExtractor.Models;
+using System.Text.Json;
+
+/// <summary>
+///     Provides facilities for transforming raw payloads into strongly-typed saved list models.
+/// </summary>
+public interface ISavedListPayloadParser
+{
+    /// <summary>
+    ///     Materialises a <see cref="SavedList"/> from the JSON payload extracted from the Google Maps page.
+    /// </summary>
+    /// <param name="payload">The parsed payload returned by <c>JSON.parse</c>.</param>
+    /// <returns>The hydrated saved list instance.</returns>
+    SavedList Parse(JsonElement payload);
+}

--- a/Service.TripperistaListExtractor/Implementations/FileWriterFactory.cs
+++ b/Service.TripperistaListExtractor/Implementations/FileWriterFactory.cs
@@ -1,0 +1,18 @@
+namespace Service.TripperistaListExtractor.Implementations;
+
+using Microsoft.Extensions.DependencyInjection;
+using Service.TripperistaListExtractor.Contracts;
+
+/// <summary>
+///     Provides factory methods that leverage the dependency injection container to create file writers.
+/// </summary>
+public sealed class FileWriterFactory(IServiceProvider serviceProvider) : IFileWriterFactory
+{
+    private readonly IServiceProvider _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+
+    /// <inheritdoc />
+    public ICsvFileWriter CreateCsvWriter() => _serviceProvider.GetRequiredService<ICsvFileWriter>();
+
+    /// <inheritdoc />
+    public IKmlFileWriter CreateKmlWriter() => _serviceProvider.GetRequiredService<IKmlFileWriter>();
+}

--- a/Service.TripperistaListExtractor/Implementations/GoogleMapsListExtractorService.cs
+++ b/Service.TripperistaListExtractor/Implementations/GoogleMapsListExtractorService.cs
@@ -1,0 +1,156 @@
+namespace Service.TripperistaListExtractor.Implementations;
+
+using System.Text;
+using System.Text.Json;
+using Core.TripperistaListExtractor.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+using Service.TripperistaListExtractor.Contracts;
+
+/// <summary>
+///     Uses Microsoft Playwright to scrape Google Maps saved list pages and build domain models.
+/// </summary>
+public sealed class GoogleMapsListExtractorService(ILogger<GoogleMapsListExtractorService> logger, ISavedListPayloadParser payloadParser)
+    : IGoogleMapsListExtractorService
+{
+    private const string PayloadStartMarker = ")]}'\n";
+    private const string PayloadEndMarker = "\\u003d13\"]";
+
+    private readonly ILogger<GoogleMapsListExtractorService> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    private readonly ISavedListPayloadParser _payloadParser = payloadParser ?? throw new ArgumentNullException(nameof(payloadParser));
+
+    /// <inheritdoc />
+    public async Task<SavedList> ExtractAsync(Uri listUri, bool verbose, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(listUri);
+
+        using var playwright = await Playwright.CreateAsync().ConfigureAwait(false);
+        await using var browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
+        {
+            Headless = true,
+            Args = new[] { "--disable-dev-shm-usage", "--no-sandbox" }
+        }).ConfigureAwait(false);
+
+        var context = await browser.NewContextAsync(new BrowserNewContextOptions
+        {
+            IgnoreHTTPSErrors = true,
+            ViewportSize = null
+        }).ConfigureAwait(false);
+
+        var page = await context.NewPageAsync().ConfigureAwait(false);
+
+        if (verbose)
+        {
+            page.Console += (_, message) => _logger.LogDebug("Playwright console: {Text}", message.Text);
+            page.PageError += (_, message) => _logger.LogWarning("Page error: {Message}", message);
+        }
+
+        _logger.LogInformation("Navigating to {Uri}", listUri);
+        await page.GotoAsync(listUri.ToString(), new PageGotoOptions
+        {
+            WaitUntil = WaitUntilState.NetworkIdle,
+            Timeout = 60000
+        }).ConfigureAwait(false);
+
+        await page.WaitForSelectorAsync("div[role=\"main\"]", new PageWaitForSelectorOptions
+        {
+            Timeout = 60000
+        }).ConfigureAwait(false);
+
+        await EnsureListFullyLoadedAsync(page, cancellationToken).ConfigureAwait(false);
+
+        var scriptContent = await page.EvaluateAsync<string>(@"() => {
+            const scripts = Array.from(document.querySelectorAll('head > script'));
+            if (scripts.length < 2) {
+                return '';
+            }
+            const target = scripts[1];
+            return target.textContent ?? '';
+        }").ConfigureAwait(false);
+
+        if (string.IsNullOrWhiteSpace(scriptContent))
+        {
+            throw new InvalidOperationException("The expected payload script could not be located.");
+        }
+
+        var payload = ExtractPayload(scriptContent);
+        var parsed = await page.EvaluateAsync<JsonElement>("payload => JSON.parse(payload)", payload).ConfigureAwait(false);
+
+        return _payloadParser.Parse(parsed);
+    }
+
+    private static async Task EnsureListFullyLoadedAsync(IPage page, CancellationToken cancellationToken)
+    {
+        var scrollableHandle = await page.QuerySelectorAsync("div[role=\"main\"] div.m6QErb.DxyBCb.kA9KIf.dS8AEf.XiKgde.ussYcc").ConfigureAwait(false);
+        if (scrollableHandle is null)
+        {
+            return;
+        }
+
+        var iterations = 0;
+        while (iterations < 200)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var scrolled = await scrollableHandle.EvaluateAsync<bool>(@"async element => {
+                const previous = element.scrollTop;
+                element.scrollBy(0, element.clientHeight);
+                await new Promise(resolve => setTimeout(resolve, 350));
+                return element.scrollTop !== previous;
+            }").ConfigureAwait(false);
+
+            if (!scrolled)
+            {
+                break;
+            }
+
+            iterations++;
+        }
+    }
+
+    private static string ExtractPayload(string scriptContent)
+    {
+        var startIndex = scriptContent.IndexOf(PayloadStartMarker, StringComparison.Ordinal);
+        if (startIndex < 0)
+        {
+            throw new InvalidOperationException("The payload start marker was not found.");
+        }
+
+        startIndex += PayloadStartMarker.Length;
+        var endIndex = scriptContent.IndexOf(PayloadEndMarker, startIndex, StringComparison.Ordinal);
+        if (endIndex < 0)
+        {
+            throw new InvalidOperationException("The payload end marker was not found.");
+        }
+
+        var rawPayload = scriptContent.Substring(startIndex, endIndex - startIndex + PayloadEndMarker.Length);
+        return SanitizePayload(rawPayload);
+    }
+
+    private static string SanitizePayload(string rawPayload)
+    {
+        if (string.IsNullOrEmpty(rawPayload))
+        {
+            return rawPayload;
+        }
+
+        var builder = new StringBuilder(rawPayload.Length);
+        for (var index = 0; index < rawPayload.Length; index++)
+        {
+            var character = rawPayload[index];
+            if (character == '\\' && index + 1 < rawPayload.Length)
+            {
+                var lookahead = rawPayload[index + 1];
+                if (lookahead == '\\' || lookahead == '"')
+                {
+                    builder.Append(lookahead);
+                    index++;
+                    continue;
+                }
+            }
+
+            builder.Append(character);
+        }
+
+        return builder.ToString();
+    }
+}

--- a/Service.TripperistaListExtractor/Parsers/SavedListPayloadParser.cs
+++ b/Service.TripperistaListExtractor/Parsers/SavedListPayloadParser.cs
@@ -1,0 +1,248 @@
+namespace Service.TripperistaListExtractor.Parsers;
+
+using System.Linq;
+using System.Text.Json;
+using Core.TripperistaListExtractor.Models;
+using Service.TripperistaListExtractor.Contracts;
+
+/// <summary>
+///     Converts the loosely structured Google Maps payload into strongly typed domain entities.
+/// </summary>
+public sealed class SavedListPayloadParser : ISavedListPayloadParser
+{
+    /// <inheritdoc />
+    public SavedList Parse(JsonElement payload)
+    {
+        if (payload.ValueKind != JsonValueKind.Array)
+        {
+            throw new InvalidOperationException("The payload root must be a JSON array.");
+        }
+
+        var list = new SavedList
+        {
+            Header = ExtractHeader(payload)
+        };
+
+        foreach (var placeNode in FindPlaceNodes(payload))
+        {
+            var place = MapPlace(placeNode);
+            if (!string.IsNullOrWhiteSpace(place.Name))
+            {
+                list.Places.Add(place);
+            }
+        }
+
+        return list;
+    }
+
+    private static SavedListHeader ExtractHeader(JsonElement root)
+    {
+        string? listName = null;
+        string? listDescription = null;
+        string? creatorName = null;
+        string? creatorImage = null;
+
+        foreach (var element in Traverse(root))
+        {
+            if (creatorName is null && TryReadCreator(element, out var potentialCreator, out var potentialImage))
+            {
+                creatorName = potentialCreator;
+                creatorImage = potentialImage;
+            }
+
+            if (element.ValueKind == JsonValueKind.String)
+            {
+                var value = element.GetString();
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    continue;
+                }
+
+                if (listName is null)
+                {
+                    listName = value;
+                    continue;
+                }
+
+                if (listDescription is null && !value.StartsWith("http", StringComparison.OrdinalIgnoreCase))
+                {
+                    listDescription = value;
+                }
+            }
+        }
+
+        return new SavedListHeader
+        {
+            Name = listName ?? string.Empty,
+            Description = listDescription,
+            Creator = creatorName ?? string.Empty,
+            CreatorImageUrl = creatorImage
+        };
+    }
+
+    private static bool TryReadCreator(JsonElement element, out string? creatorName, out string? creatorImage)
+    {
+        creatorName = null;
+        creatorImage = null;
+
+        if (element.ValueKind != JsonValueKind.Array)
+        {
+            return false;
+        }
+
+        var values = element.EnumerateArray().ToArray();
+        if (values.Length < 3)
+        {
+            return false;
+        }
+
+        if (values[0].ValueKind == JsonValueKind.String &&
+            values[1].ValueKind == JsonValueKind.String &&
+            values[2].ValueKind == JsonValueKind.String &&
+            values[1].GetString()?.StartsWith("http", StringComparison.OrdinalIgnoreCase) == true)
+        {
+            creatorName = values[0].GetString();
+            creatorImage = values[1].GetString();
+            return true;
+        }
+
+        return false;
+    }
+
+    private static IEnumerable<JsonElement> Traverse(JsonElement element)
+    {
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.Array:
+                foreach (var item in element.EnumerateArray())
+                {
+                    yield return item;
+                    foreach (var nested in Traverse(item))
+                    {
+                        yield return nested;
+                    }
+                }
+
+                break;
+            case JsonValueKind.Object:
+                foreach (var property in element.EnumerateObject())
+                {
+                    yield return property.Value;
+                    foreach (var nested in Traverse(property.Value))
+                    {
+                        yield return nested;
+                    }
+                }
+
+                break;
+        }
+    }
+
+    private static IEnumerable<JsonElement> FindPlaceNodes(JsonElement root)
+    {
+        if (root.ValueKind == JsonValueKind.Array)
+        {
+            var values = root.EnumerateArray().ToArray();
+            if (IsPlaceNode(values))
+            {
+                yield return root;
+            }
+
+            foreach (var child in values)
+            {
+                foreach (var nested in FindPlaceNodes(child))
+                {
+                    yield return nested;
+                }
+            }
+        }
+        else if (root.ValueKind == JsonValueKind.Object)
+        {
+            foreach (var property in root.EnumerateObject())
+            {
+                foreach (var nested in FindPlaceNodes(property.Value))
+                {
+                    yield return nested;
+                }
+            }
+        }
+    }
+
+    private static bool IsPlaceNode(IReadOnlyList<JsonElement> nodeValues)
+    {
+        if (nodeValues.Count < 3)
+        {
+            return false;
+        }
+
+        var metadata = nodeValues[1];
+        var nameElement = nodeValues[2];
+        if (metadata.ValueKind != JsonValueKind.Array || nameElement.ValueKind != JsonValueKind.String)
+        {
+            return false;
+        }
+
+        var metadataValues = metadata.EnumerateArray().ToArray();
+        if (metadataValues.Length < 6)
+        {
+            return false;
+        }
+
+        var coordinateElement = metadataValues[5];
+        if (coordinateElement.ValueKind != JsonValueKind.Array)
+        {
+            return false;
+        }
+
+        var coordinateValues = coordinateElement.EnumerateArray().ToArray();
+        if (coordinateValues.Length < 4)
+        {
+            return false;
+        }
+
+        return coordinateValues[2].ValueKind == JsonValueKind.Number && coordinateValues[3].ValueKind == JsonValueKind.Number;
+    }
+
+    private static SavedPlace MapPlace(JsonElement node)
+    {
+        var values = node.EnumerateArray().ToArray();
+        var metadataValues = values[1].EnumerateArray().ToArray();
+        var coordinateValues = metadataValues[5].EnumerateArray().ToArray();
+
+        var place = new SavedPlace
+        {
+            Name = values[2].GetString() ?? string.Empty,
+            Address = metadataValues.Length > 2 && metadataValues[2].ValueKind == JsonValueKind.String
+                ? metadataValues[2].GetString()
+                : null,
+            Latitude = coordinateValues[2].GetDouble(),
+            Longitude = coordinateValues[3].GetDouble(),
+            Note = values.Length > 3 && values[3].ValueKind == JsonValueKind.String ? values[3].GetString() : null,
+            ImageUrl = TryReadImage(values)
+        };
+
+        return place;
+    }
+
+    private static string? TryReadImage(IReadOnlyList<JsonElement> values)
+    {
+        if (values.Count <= 17)
+        {
+            return null;
+        }
+
+        var contributorElement = values[17];
+        if (contributorElement.ValueKind != JsonValueKind.Array)
+        {
+            return null;
+        }
+
+        var contributorValues = contributorElement.EnumerateArray().ToArray();
+        if (contributorValues.Length < 2)
+        {
+            return null;
+        }
+
+        return contributorValues[1].ValueKind == JsonValueKind.String ? contributorValues[1].GetString() : null;
+    }
+}

--- a/Service.TripperistaListExtractor/Service.TripperistaListExtractor.csproj
+++ b/Service.TripperistaListExtractor/Service.TripperistaListExtractor.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="CsvHelper" Version="30.0.1" />
+    <PackageReference Include="Microsoft.Playwright" Version="1.49.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Core.TripperistaListExtractor/Core.TripperistaListExtractor.csproj" />
+  </ItemGroup>
+</Project>

--- a/Service.TripperistaListExtractor/Writers/CsvFileWriter.cs
+++ b/Service.TripperistaListExtractor/Writers/CsvFileWriter.cs
@@ -1,0 +1,83 @@
+namespace Service.TripperistaListExtractor.Writers;
+
+using System.Globalization;
+using System.IO;
+using System.Text;
+using CsvHelper;
+using CsvHelper.Configuration;
+using Core.TripperistaListExtractor.Models;
+using Microsoft.Extensions.Logging;
+using Service.TripperistaListExtractor.Contracts;
+
+/// <summary>
+///     Implements CSV serialisation using the CsvHelper library.
+/// </summary>
+public sealed class CsvFileWriter(ILogger<CsvFileWriter> logger) : ICsvFileWriter
+{
+    private readonly ILogger<CsvFileWriter> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+    /// <inheritdoc />
+    public async Task WriteAsync(SavedList list, string filePath, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(list);
+        ArgumentNullException.ThrowIfNull(filePath);
+
+        var directory = Path.GetDirectoryName(filePath);
+        if (!string.IsNullOrWhiteSpace(directory) && !Directory.Exists(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        var configuration = new CsvConfiguration(CultureInfo.InvariantCulture)
+        {
+            Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+            LeaveOpen = false,
+            NewLine = Environment.NewLine
+        };
+
+        await using var stream = new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.Read, 4096, useAsync: true);
+        await using var writer = new StreamWriter(stream, configuration.Encoding, bufferSize: 1024, leaveOpen: false);
+        await using var csvWriter = new CsvWriter(writer, configuration);
+
+        csvWriter.Context.RegisterClassMap<PlaceRecordMap>();
+
+        await csvWriter.WriteHeaderAsync<PlaceRecord>(cancellationToken).ConfigureAwait(false);
+        await csvWriter.NextRecordAsync().ConfigureAwait(false);
+
+        foreach (var place in list.Places)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var record = new PlaceRecord(list.Header.Name, place.Name, place.Address, place.Latitude, place.Longitude, place.Note, place.ImageUrl);
+            await csvWriter.WriteRecordAsync(record, cancellationToken).ConfigureAwait(false);
+            await csvWriter.NextRecordAsync().ConfigureAwait(false);
+        }
+
+        await csvWriter.FlushAsync().ConfigureAwait(false);
+        await writer.FlushAsync().ConfigureAwait(false);
+
+        _logger.LogDebug("CSV output written to {FilePath}", filePath);
+    }
+
+    private sealed record PlaceRecord(
+        string ListName,
+        string PlaceName,
+        string? Address,
+        double? Latitude,
+        double? Longitude,
+        string? Note,
+        string? ImageUrl);
+
+    private sealed class PlaceRecordMap : ClassMap<PlaceRecord>
+    {
+        public PlaceRecordMap()
+        {
+            Map(record => record.ListName).Name("ListName");
+            Map(record => record.PlaceName).Name("PlaceName");
+            Map(record => record.Address).Name("Address");
+            Map(record => record.Latitude).Name("Latitude");
+            Map(record => record.Longitude).Name("Longitude");
+            Map(record => record.Note).Name("Note");
+            Map(record => record.ImageUrl).Name("ImageUrl");
+        }
+    }
+}

--- a/Service.TripperistaListExtractor/Writers/KmlFileWriter.cs
+++ b/Service.TripperistaListExtractor/Writers/KmlFileWriter.cs
@@ -1,0 +1,87 @@
+namespace Service.TripperistaListExtractor.Writers;
+
+using System.Globalization;
+using System.IO;
+using System.Text;
+using System.Xml.Linq;
+using Core.TripperistaListExtractor.Models;
+using Microsoft.Extensions.Logging;
+using Service.TripperistaListExtractor.Contracts;
+
+/// <summary>
+///     Serialises the saved list into the Keyhole Markup Language format.
+/// </summary>
+public sealed class KmlFileWriter(ILogger<KmlFileWriter> logger) : IKmlFileWriter
+{
+    private readonly ILogger<KmlFileWriter> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+    /// <inheritdoc />
+    public async Task WriteAsync(SavedList list, string filePath, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(list);
+        ArgumentNullException.ThrowIfNull(filePath);
+
+        var directory = Path.GetDirectoryName(filePath);
+        if (!string.IsNullOrWhiteSpace(directory) && !Directory.Exists(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        var kmlNamespace = XNamespace.Get("http://www.opengis.net/kml/2.2");
+        var documentElement = new XElement(kmlNamespace + "Document",
+            new XElement(kmlNamespace + "name", list.Header.Name),
+            new XElement(kmlNamespace + "description", list.Header.Description ?? string.Empty));
+
+        foreach (var place in list.Places)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var placemark = new XElement(kmlNamespace + "Placemark",
+                new XElement(kmlNamespace + "name", place.Name),
+                new XElement(kmlNamespace + "description", BuildDescriptionFragment(place)),
+                new XElement(kmlNamespace + "Point",
+                    new XElement(kmlNamespace + "coordinates", FormatCoordinates(place.Longitude, place.Latitude))));
+
+            documentElement.Add(placemark);
+        }
+
+        var kmlDocument = new XDocument(
+            new XDeclaration("1.0", "utf-8", "yes"),
+            new XElement(kmlNamespace + "kml", documentElement));
+
+        await using var stream = new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.Read, 4096, useAsync: true);
+        await Task.Run(() => kmlDocument.Save(stream), cancellationToken).ConfigureAwait(false);
+
+        _logger.LogDebug("KML output written to {FilePath}", filePath);
+    }
+
+    private static string FormatCoordinates(double? longitude, double? latitude)
+    {
+        if (longitude is null || latitude is null)
+        {
+            return string.Empty;
+        }
+
+        return string.Create(CultureInfo.InvariantCulture, $"{longitude.Value},{latitude.Value},0");
+    }
+
+    private static string BuildDescriptionFragment(SavedPlace place)
+    {
+        var builder = new StringBuilder();
+        if (!string.IsNullOrWhiteSpace(place.Address))
+        {
+            builder.AppendLine(place.Address);
+        }
+
+        if (!string.IsNullOrWhiteSpace(place.Note))
+        {
+            builder.AppendLine(place.Note);
+        }
+
+        if (!string.IsNullOrWhiteSpace(place.ImageUrl))
+        {
+            builder.Append("Image: ").Append(place.ImageUrl);
+        }
+
+        return builder.ToString().Trim();
+    }
+}

--- a/TripperistaListExtractor.sln
+++ b/TripperistaListExtractor.sln
@@ -1,0 +1,39 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.7.34202.233
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Console.TripperistaListExtractor", "Console.TripperistaListExtractor\Console.TripperistaListExtractor.csproj", "{2C1D634E-3F49-4556-848D-AB250FBC135B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Core.TripperistaListExtractor", "Core.TripperistaListExtractor\Core.TripperistaListExtractor.csproj", "{0F97159B-8194-470C-939A-21EE2EF2E678}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Service.TripperistaListExtractor", "Service.TripperistaListExtractor\Service.TripperistaListExtractor.csproj", "{031386A5-1DB7-450A-BC51-AB95A955A4E9}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Console.TripperistaListExtractor.Tests", "Console.TripperistaListExtractor.Tests\Console.TripperistaListExtractor.Tests.csproj", "{F408BA35-333C-48DF-ABBC-3C370829F47B}"
+EndProject
+Global
+GlobalSection(SolutionConfigurationPlatforms) = preSolution
+Debug|Any CPU = Debug|Any CPU
+Release|Any CPU = Release|Any CPU
+EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{2C1D634E-3F49-4556-848D-AB250FBC135B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{2C1D634E-3F49-4556-848D-AB250FBC135B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{2C1D634E-3F49-4556-848D-AB250FBC135B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{2C1D634E-3F49-4556-848D-AB250FBC135B}.Release|Any CPU.Build.0 = Release|Any CPU
+{0F97159B-8194-470C-939A-21EE2EF2E678}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{0F97159B-8194-470C-939A-21EE2EF2E678}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{0F97159B-8194-470C-939A-21EE2EF2E678}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{0F97159B-8194-470C-939A-21EE2EF2E678}.Release|Any CPU.Build.0 = Release|Any CPU
+{031386A5-1DB7-450A-BC51-AB95A955A4E9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{031386A5-1DB7-450A-BC51-AB95A955A4E9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{031386A5-1DB7-450A-BC51-AB95A955A4E9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{031386A5-1DB7-450A-BC51-AB95A955A4E9}.Release|Any CPU.Build.0 = Release|Any CPU
+{F408BA35-333C-48DF-ABBC-3C370829F47B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{F408BA35-333C-48DF-ABBC-3C370829F47B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{F408BA35-333C-48DF-ABBC-3C370829F47B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{F408BA35-333C-48DF-ABBC-3C370829F47B}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
+GlobalSection(SolutionProperties) = preSolution
+HideSolutionNode = FALSE
+EndGlobalSection
+EndGlobal


### PR DESCRIPTION
## Summary
- add a multi-project .NET solution with console, core, service, and test projects
- implement a Playwright-driven extractor with CSV/KML writers and resource-managed logging
- provide configuration, command handling, and sample tests for the saved list payload parser

## Testing
- not run (dotnet CLI unavailable in execution environment)


------
https://chatgpt.com/codex/tasks/task_b_68e0288d96208330bb11217162a9fa11